### PR TITLE
Fixes for dbplyr 2.0.0

### DIFF
--- a/tests/testthat/test-dbplyr-integration.R
+++ b/tests/testthat/test-dbplyr-integration.R
@@ -48,8 +48,8 @@ tailnum_delay <- flights_db %>%
     delay = mean(arr_delay, na.rm = TRUE),
     n = n()
   ) %>%
-  arrange(desc(delay)) %>%
   filter(n > 100) %>%
+  arrange(desc(delay)) %>%
   collect()
 
 dbDisconnect(con)
@@ -76,7 +76,7 @@ with_mock_db({
   # our flights table
   expect_warning(
     flights_db <- tbl(con, "flights"),
-    "dbFetch `n` is ignored while mocking databases\\."
+    if (packageVersion("dbplyr") > "1.99") NA else "dbFetch `n` is ignored while mocking databases\\."
   )
 
   test_that("We can select columns", {
@@ -111,8 +111,8 @@ with_mock_db({
         delay = mean(arr_delay, na.rm = TRUE),
         n = n()
       ) %>%
-      arrange(desc(delay)) %>%
       filter(n > 100) %>%
+      arrange(desc(delay)) %>%
       collect()
 
     expect_identical(result, tailnum_delay)


### PR DESCRIPTION
* tbl() no longer generates a warning (because db_query_fields() no longer sets n when calling dbFetch())

* Moved arrange() later in pipeline to avoid it being omitted from subqueries