### PR TITLE
Change in path for `createuser`

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,1 +1,2 @@
-linters: with_defaults(line_length_linter(100), object_name_linter = lintr::object_name_linter(styles = c("snake_case", "camelCase")), object_usage_linter = NULL, cyclocomp_linter = cyclocomp_linter(22))
+linters: linters_with_defaults(line_length_linter(100), object_name_linter = lintr::object_name_linter(styles = c("snake_case", "camelCase")), object_usage_linter = NULL, cyclocomp_linter = cyclocomp_linter(22))
+exclusions: list("vignettes/dittodb.R", "vignettes/dittodb")

--- a/R/nycflights13-sql.R
+++ b/R/nycflights13-sql.R
@@ -47,7 +47,7 @@ nycflights13_create_sql <- function(con, schema = "", ...) {
     weather = list(c("year", "month", "day"), "origin")
   )
 
-  if (inherits(con, "SQLiteConnection") | schema == "") {
+  if (inherits(con, "SQLiteConnection") || schema == "") {
     # we don't have schema information or it's not compatible, proceed without.
     remote_tables <- dbListTables(con)
   } else {

--- a/db-setup/postgres-brew.sh
+++ b/db-setup/postgres-brew.sh
@@ -13,5 +13,5 @@ UsageCount      = 1
 EOT
 initdb /usr/local/var/postgres
 pg_ctl -D /usr/local/var/postgres start
-/usr/local/opt/postgres/bin/createuser -s postgres
+createuser -s postgres
 sleep 10

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -25,4 +25,4 @@ RSQLiteConnection
 standardised
 tabset
 testthat
-travelling
+

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -45,8 +45,6 @@ navbar:
       menu:
       - text: Getting Started with dittodb
         href: articles/dittodb.html
-      - text: Recording SQL queries with dittodb for travelling
-        href: articles/travelling.html
       - text: nycflights data
         href: articles/nycflights.html
       - text: Developing dittodb


### PR DESCRIPTION
... which only impacted the macOS runners. Rely on path itself to find it now.

Also cleaned up some new lintr comments + removed the "travelling" vignette since there are much better ways to do something like that now (e.g. {duckdb})