### PR TITLE
Allow for bigint roundtripping

### DIFF
--- a/.github/workflows/check-linux-testthat-2e-3e.yaml
+++ b/.github/workflows/check-linux-testthat-2e-3e.yaml
@@ -33,7 +33,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Cache R packages
         uses: actions/cache@v2

--- a/.github/workflows/check-linux-testthat-2e-3e.yaml
+++ b/.github/workflows/check-linux-testthat-2e-3e.yaml
@@ -26,7 +26,7 @@ jobs:
       RSPM: "https://packagemanager.rstudio.com/all/__linux__/focal/latest"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/check-linux.yaml
+++ b/.github/workflows/check-linux.yaml
@@ -32,14 +32,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-tinytex@master
+      - uses: r-lib/actions/setup-tinytex@v2
         if: contains(matrix.config.args, 'no-manual') == false
 
       - name: Install dependencies (linux)

--- a/.github/workflows/check-linux.yaml
+++ b/.github/workflows/check-linux.yaml
@@ -30,7 +30,7 @@ jobs:
       RSPM: "https://packagemanager.rstudio.com/all/__linux__/focal/latest"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/check-macOS.yaml
+++ b/.github/workflows/check-macOS.yaml
@@ -23,7 +23,7 @@ jobs:
       DITTODB_ENABLE_MARIA_TESTS: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/check-macOS.yaml
+++ b/.github/workflows/check-macOS.yaml
@@ -39,9 +39,9 @@ jobs:
             sudo ln -s /Library/Frameworks/R.framework/Resources/bin/Rscript .
           fi
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-tinytex@v1
+      - uses: r-lib/actions/setup-tinytex@v2
         if: contains(matrix.config.args, 'no-manual') == false
 
       - name: Install databases (macOS)

--- a/.github/workflows/check-windows.yaml
+++ b/.github/workflows/check-windows.yaml
@@ -29,9 +29,9 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-tinytex@v1
+      - uses: r-lib/actions/setup-tinytex@v2
         if: contains(matrix.config.args, 'no-manual') == false
 
       - name: Cache Windows Chocolatey downloads

--- a/.github/workflows/check-windows.yaml
+++ b/.github/workflows/check-windows.yaml
@@ -23,7 +23,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown-codemeta.yaml
+++ b/.github/workflows/pkgdown-codemeta.yaml
@@ -10,7 +10,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'

--- a/.github/workflows/pkgdown-codemeta.yaml
+++ b/.github/workflows/pkgdown-codemeta.yaml
@@ -11,10 +11,10 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
       - name: Install databases (macOS)
         run: |
            bash db-setup/postgres-brew.sh

--- a/R/capture-requests.R
+++ b/R/capture-requests.R
@@ -176,7 +176,7 @@ recordFetch <- quote({
     message("Writing to ", .dittodb_env$curr_file_path)
   }
   out <- redact_columns(ans, columns = get_redactor())
-  dput(out, .dittodb_env$curr_file_path, control = c("all", "hexNumeric"))
+  dput(out, .dittodb_env$curr_file_path, control = c("all", "digits17"))
 })
 
 dbConnectTrace <- quote({
@@ -212,7 +212,7 @@ dbListTablesTrace <- quote({
   dput(
     thing,
     file.path(.dittodb_env$db_path, "dbListTables.R"),
-    control = c("all", "hexNumeric")
+    control = c("all", "digits17")
   )
 })
 
@@ -222,7 +222,7 @@ dbListFieldsTrace <- quote({
   dput(
     thing,
     file.path(.dittodb_env$db_path, glue::glue("dbListFields-{name}.R")),
-    control = c("all", "hexNumeric")
+    control = c("all", "digits17")
   )
 })
 
@@ -232,7 +232,7 @@ dbExistsTableTrace <- quote({
   dput(
     thing,
     file.path(.dittodb_env$db_path, glue::glue("dbExistsTable-{name}.R")),
-    control = c("all", "hexNumeric")
+    control = c("all", "digits17")
   )
 })
 
@@ -242,7 +242,7 @@ dbGetInfoConTrace <- quote({
   if (length(path) > 0) {
     # generally .dittodb_env$db_path is not-null, but RPostgreSQL uses
     # dbGetInfo in the connection process, don't record mocks then.
-    dput(thing, path, control = c("all", "hexNumeric"))
+    dput(thing, path, control = c("all", "digits17"))
   }
 })
 
@@ -257,7 +257,7 @@ dbGetInfoResultTrace <- quote({
     # TODO: some default?
   }
   path <- make_path(.dittodb_env$db_path, "resultInfo", hash)
-  dput(thing, path, control = c("all", "hexNumeric"))
+  dput(thing, path, control = c("all", "digits17"))
 })
 
 dbGetInfoPsqlresultTrace <- quote({
@@ -268,7 +268,7 @@ dbGetInfoPsqlresultTrace <- quote({
   if (length(path) > 0) {
     # generally .dittodb_env$db_path is not-null, but RPostgreSQL uses
     # dbGetInfo in the connection process, don't record mocks then.
-    dput(thing, path, control = c("all", "hexNumeric"))
+    dput(thing, path, control = c("all", "digits17"))
   }
 })
 
@@ -287,7 +287,7 @@ dbColumnInfoTrace <- quote({
     # TODO: some default?
   }
   path <- make_path(.dittodb_env$db_path, "columnInfo", hash)
-  dput(thing, path, control = c("all", "hexNumeric"))
+  dput(thing, path, control = c("all", "digits17"))
 })
 
 dbGetRowsAffectedTrace <- quote({
@@ -304,7 +304,7 @@ dbGetRowsAffectedTrace <- quote({
     # TODO: some default?
   }
   path <- make_path(.dittodb_env$db_path, "dbGetRowsAffected", hash)
-  dput(thing, path, control = c("all", "hexNumeric"))
+  dput(thing, path, control = c("all", "digits17"))
 })
 
 #' @rdname capture_requests

--- a/db-setup/postgres-nycflights.sql
+++ b/db-setup/postgres-nycflights.sql
@@ -182,17 +182,18 @@ ALTER TABLE rpostgres.airports OWNER TO travis;
 
 --
 -- Name: flights; Type: TABLE; Schema: rpostgres; Owner: travis
+-- times are bigints so that we get more type coverage (especially with bit64)
 --
 
 CREATE TABLE rpostgres.flights (
     year integer,
     month integer,
     day integer,
-    dep_time integer,
-    sched_dep_time integer,
+    dep_time bigint,
+    sched_dep_time bigint,
     dep_delay real,
-    arr_time integer,
-    sched_arr_time integer,
+    arr_time bigint,
+    sched_arr_time bigint,
     arr_delay real,
     carrier text,
     flight integer,


### PR DESCRIPTION
resolves #165 

It turns out that bigints won't roundtrip with `control = "hexNumeric"` (https://github.com/truecluster/bit64/issues/27). Switching to `digits17` for now (thought we might want to _only_ use that in cases where we detect a 64 bit integer | bigint).