### PR TITLE
Allow for some nameless databases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ Suggests:
     withr,
     rmarkdown,
     lintr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Language: en-US
 VignetteBuilder: knitr

--- a/R/capture-requests.R
+++ b/R/capture-requests.R
@@ -182,7 +182,7 @@ recordFetch <- quote({
 dbConnectTrace <- quote({
   .dittodb_env$db_path <- file.path(
     db_mock_paths()[1],
-    get_dbname(list(...))
+    get_dbname(list(...), drv = drv)
   )
   dir.create(.dittodb_env$db_path, showWarnings = FALSE, recursive = TRUE)
 })

--- a/R/connection.R
+++ b/R/connection.R
@@ -79,7 +79,7 @@ dbMockConnect <- function(drv, ...) {
     original_class <- "DBIConnection"
   }
 
-  path <- get_dbname(dots)
+  path <- get_dbname(dots, drv = drv)
 
   # retrieve the dbplyr_edition for the original connection, if it exists (and
   # if dbplyr is installed)

--- a/R/quote.R
+++ b/R/quote.R
@@ -5,6 +5,8 @@ setMethod(
   "dbQuoteIdentifier",
   c("DBIMockRPostgresConnection", "character"),
   function(conn, x, ...) {
+    # double up any quotes we see before quoting
+    x <- gsub('"', '""', x)
     return(SQL(glue('"{x}"'), names = names(x)))
   })
 

--- a/man/get_dbname.Rd
+++ b/man/get_dbname.Rd
@@ -4,10 +4,12 @@
 \alias{get_dbname}
 \title{Get the \code{dbname} from a connection call}
 \usage{
-get_dbname(dots)
+get_dbname(dots, drv = NULL)
 }
 \arguments{
 \item{dots}{from the argument being passed to the connection}
+
+\item{drv}{from the argument being passed to the connection}
 }
 \value{
 the name, sanitized if needed

--- a/man/mock-db-methods.Rd
+++ b/man/mock-db-methods.Rd
@@ -33,6 +33,7 @@
 \alias{dbGetInfo,DBIMockResult-method}
 \alias{dbQuoteIdentifier,DBIMockRPostgresConnection,character-method}
 \alias{dbQuoteIdentifier,DBIMockRPostgresConnection,SQL-method}
+\alias{dbQuoteIdentifier,DBIMockRPostgresConnection,ident-method}
 \alias{dbQuoteString,DBIMockRPostgresConnection,character-method}
 \alias{dbQuoteString,DBIMockRPostgresConnection,SQL-method}
 \alias{dbQuoteString,DBIMockMariaDBConnection,character-method}
@@ -91,6 +92,8 @@ dbMockConnect(drv, ...)
 \S4method{dbQuoteIdentifier}{DBIMockRPostgresConnection,character}(conn, x, ...)
 
 \S4method{dbQuoteIdentifier}{DBIMockRPostgresConnection,SQL}(conn, x, ...)
+
+\S4method{dbQuoteIdentifier}{DBIMockRPostgresConnection,ident}(conn, x, ...)
 
 \S4method{dbQuoteString}{DBIMockRPostgresConnection,character}(conn, x, ...)
 

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -7,12 +7,32 @@ test_that("Error handling", {
   )
 })
 
+test_that("And that RSQLite, without anything captures", {
+  capture_db_requests({
+    con <- dbConnect(RSQLite::SQLite())
+    expect_identical(.dittodb_env$db_path, file.path(temp_dir, "ephemeral_sqlite"))
+    dbDisconnect(con)
+  },
+  path = temp_dir
+  )
+})
+
+
 with_mock_db({
   test_that("Our connection is a mock connection", {
     # ":memory:" is non-portable, so using something close, but portable
     con <- dbConnect(RSQLite::SQLite(), "memory")
     expect_s4_class(con, "DBIMockConnection")
     expect_identical(con@path, "memory")
+    expect_identical(con@original_class, "SQLiteConnection")
+
+    dbDisconnect(con)
+  })
+
+  test_that("And that RSQLite, without anything works", {
+    con <- dbConnect(RSQLite::SQLite())
+    expect_s4_class(con, "DBIMockConnection")
+    # expect_identical(con@path, "memory")
     expect_identical(con@original_class, "SQLiteConnection")
 
     dbDisconnect(con)

--- a/tests/testthat/test-dbi-sqlite-integration.R
+++ b/tests/testthat/test-dbi-sqlite-integration.R
@@ -65,17 +65,6 @@ with_mock_db({
 
 
   test_that("Error handling", {
-    expect_error(
-      dbConnect(RSQLite::SQLite()),
-      "There was no dbname, so I don't know where to look for mocks."
-    )
-
-    expect_error(
-      dbConnect(RSQLite::SQLite(), dbname = ""),
-      "There was no dbname, so I don't know where to look for mocks."
-    )
-
-
     result <- dbSendQuery(con, "SELECT * FROM airlines LIMIT 2")
     expect_warning(
       dbFetch(result, n = 1),

--- a/tests/testthat/test-quote.R
+++ b/tests/testthat/test-quote.R
@@ -14,6 +14,11 @@ test_that("quoting works", {
   expect_identical(dbQuoteString(con_mockmaria, "foo"), SQL("'foo'"))
   expect_identical(dbQuoteString(con_rpostgres, "foo"), SQL("'foo'"))
   expect_identical(dbQuoteIdentifier(con_rpostgres, "foo"), SQL('"foo"'))
+  # dplyr ident-style
+  expect_identical(
+    dbQuoteIdentifier(con_rpostgres, '"rpostgres"."airlines"'),
+    SQL('"""rpostgres"".""airlines"""')
+  )
   # However, MariaDB is slightly different (we haven't redefined it, since it
   # doesn't communicate with the DB first)
   expect_identical(dbQuoteIdentifier(con_mockmaria, "foo"), SQL("`foo`"))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -167,4 +167,7 @@ test_that("get_dbname() works", {
   expect_error(get_dbname(list()))
   # Legitimate error
   expect_error(get_dbname(list(bogus = "oops")))
+  # Empty argument, but that's ok for SQLite
+  expect_equal(get_dbname(list(), drv = RSQLite::SQLite()), "ephemeral_sqlite")
+  expect_equal(get_dbname(list(dbname = ""), drv = RSQLite::SQLite()), "ephemeral_sqlite")
 })

--- a/vignettes/dittodb.Rmd
+++ b/vignettes/dittodb.Rmd
@@ -46,7 +46,7 @@ stop_db_capturing()
 ```
 
 ## Our function `mean_delays()` {.tabset}
-To get started, imagine that we are working on a package that queries a database that consists of the [nycflights13 data](nycflights.html). We have the following function which takes a column to aggregate by and returns a dataframe with that column and the mean delay for groups based on the values in the column name given.
+To get started, imagine that we are working on a package that queries a database that consists of the [nycflights13 data](nycflights.html)[^1]. We have the following function which takes a column to aggregate by and returns a dataframe with that column and the mean delay for groups based on the values in the column name given.
 
 ### RMariaDB
 ```{r mean_delays}
@@ -93,7 +93,10 @@ mean_delays <- function(group_col) {
 library(DBI)
 
 mean_delays <- function(group_col) {
-  con <- dbConnect(RSQLite::SQLite())
+  con <- dbConnect(
+    RSQLite::SQLite(),
+    dbname = "nycflights"
+  )
   on.exit(dbDisconnect(con))
 
   query <- glue::glue(
@@ -247,3 +250,6 @@ df_fixt <- dplyr::filter(df_fixt, month <= 2 & day < 10)
 # save the fixture for use in tests
 dput(df_fixt, file = "nycflights/SELECT-16d120.R", control = c("all", "hexNumeric"))
 ```
+
+
+[^1]: These code snippets won't work right out of the box — you will need to make sure the database you're connecting to has the [nycflights13 data](nycflights.html) data in it. You could do this with SQLite by running `nycflights13_create_sqlite(location = "nycflights")` before the rest of the commands here.


### PR DESCRIPTION
Closes #171 

Also:
* clarifies in the getting started vignette how to get the data (for SQLite at least)
* adds double quoting bug that was uncovered by dbplyr updates