### PR TITLE
docs: fix pkgdown config for rotemplate compatibility

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -49,6 +49,10 @@ navbar:
         href: articles/nycflights.html
       - text: Developing dittodb
         href: articles/developing-dittodb.html
+news:
+  releases:
+  - text: "Version 1.0.0"
+    href: https://jonkeane.com/blog/introducing_dittodb/
 
 authors:
   Jonathan Keane:

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -36,27 +36,19 @@ reference:
 navbar:
   title: dittodb
   type: default
-  left:
-    - text: Get started
-      href: articles/dittodb.html
-    - text: Reference
-      href: reference/
-    - text: Articles
-      menu:
+  structure:
+    left: [intro, reference, articles, news]
+    right: [search, github]
+  components:
+   articles:
+    text: Articles
+    menu:
       - text: Getting Started with dittodb
         href: articles/dittodb.html
       - text: nycflights data
         href: articles/nycflights.html
       - text: Developing dittodb
         href: articles/developing-dittodb.html
-    - text: News
-      menu:
-      - text: "Changelog"
-        href: news/index.html
-      - text: "------------------"
-      - text: "Blog posts"
-      - text: "dittodb 0.1.0"
-        href: https://jonkeane.com/blog/introducing_dittodb/
 
 authors:
   Jonathan Keane:


### PR DESCRIPTION
:wave: @jonkeane 

I noticed that on https://docs.ropensci.org/dittodb/ the navbar has duplicated content.

With the config in this PR, I think you get the right navbar for both your own pkgdown docs and for the rOpenSci branded ones. Screenshots below.

![image](https://user-images.githubusercontent.com/8360597/230344795-a31b12f8-d681-4485-9243-c722529edac9.png)
![image](https://user-images.githubusercontent.com/8360597/230344845-985d4ace-c9ed-4193-b640-9f4c1628777b.png)
