### PR TITLE
fix: Establish compatibility with upcoming DBI 1.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,6 +61,8 @@ Suggests:
     testthat,
     withr,
     rmarkdown
+Remotes: 
+    r-dbi/DBI@cran-1.3.0
 RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,8 +61,6 @@ Suggests:
     testthat,
     withr,
     rmarkdown
-Remotes: 
-    r-dbi/DBI@cran-1.3.0
 RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# dittodb 0.1.11
+* Established compatibility with DBI 1.3.0 (#197)
+
 # dittodb 0.1.10
 * Updated links to match CRAN checks (#195)
 

--- a/R/capture-requests.R
+++ b/R/capture-requests.R
@@ -381,7 +381,7 @@ safe_untrace <- function(what, where = sys.frame()) {
 
   if (inherits(
     try(get(what, env), silent = TRUE),
-    c("functionWithTrace", "standardGenericWithTrace")
+    c("functionWithTrace", "standardGenericWithTrace", "nonstandardGenericFunctionWithTrace")
   )) {
     quietly(untrace(what, where = where))
   }

--- a/R/capture-requests.R
+++ b/R/capture-requests.R
@@ -366,6 +366,14 @@ method_loaded <- Vectorize(function(method, signature) {
   return(any(grepl(signature, methods(method))))
 }, vectorize.args = "signature")
 
+# reused in a few places
+is_traced <- function(x) {
+  inherits(
+    x,
+    c("functionWithTrace", "standardGenericWithTrace", "nonstandardGenericFunctionWithTrace")
+  )
+}
+
 # borrowed from httptest
 safe_untrace <- function(what, where = sys.frame()) {
   ## If you attempt to untrace a function (1) that isn't exported from
@@ -379,10 +387,7 @@ safe_untrace <- function(what, where = sys.frame()) {
     env <- environment(where)
   }
 
-  if (inherits(
-    try(get(what, env), silent = TRUE),
-    c("functionWithTrace", "standardGenericWithTrace", "nonstandardGenericFunctionWithTrace")
-  )) {
+  if (is_traced(try(get(what, env), silent = TRUE))) {
     quietly(untrace(what, where = where))
   }
 }

--- a/R/mock-db.R
+++ b/R/mock-db.R
@@ -106,10 +106,10 @@ stop_mock_db <- function() {
   mocked_already <- any(
     inherits(
       try(get("dbConnect", sys.frame()), silent = TRUE),
-      c("functionWithTrace", "standardGenericWithTrace")
+      c("functionWithTrace", "standardGenericWithTrace", "nonstandardGenericFunctionWithTrace")
     ), inherits(
       try(get("dbConnect", asNamespace("DBI")), silent = TRUE),
-      c("functionWithTrace", "standardGenericWithTrace")
+      c("functionWithTrace", "standardGenericWithTrace", "nonstandardGenericFunctionWithTrace")
     )
   )
 

--- a/R/mock-db.R
+++ b/R/mock-db.R
@@ -104,13 +104,8 @@ start_mock_db <- function() {
 #' @export
 stop_mock_db <- function() {
   mocked_already <- any(
-    inherits(
-      try(get("dbConnect", sys.frame()), silent = TRUE),
-      c("functionWithTrace", "standardGenericWithTrace", "nonstandardGenericFunctionWithTrace")
-    ), inherits(
-      try(get("dbConnect", asNamespace("DBI")), silent = TRUE),
-      c("functionWithTrace", "standardGenericWithTrace", "nonstandardGenericFunctionWithTrace")
-    )
+    is_traced(try(get("dbConnect", sys.frame()), silent = TRUE)),
+    is_traced(try(get("dbConnect", asNamespace("DBI")), silent = TRUE))
   )
 
   if (!mocked_already) {


### PR DESCRIPTION
DBI 1.3.0 adds support for OpenTelemetry tracing. See https://github.com/tidyverse/tidyverse.org/pull/786 for context.

We change the definition of generics including `dbConnect()` . This package currently relies on the generic being of class `"standardGenericWithTrace"` _after establishing the trace_, in DBI 1.3.0 this will be `"nonstandardGenericFunctionWithTrace"` (from tests on my system).

Checks are currently running with CRAN DBI, I'll add a "Remotes" in the next commit to also check against dev DBI. I'll also introduce a new function for this inheritance check.

This is the only true breakage for the upcoming DBI release, as far as CRAN is concerned.

@jonkeane: Would you be able to submit a micro-update with this change soon-ish? Thanks!